### PR TITLE
MB-30798 & MB-30302

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -31,13 +31,13 @@ endif()
 
 find_package(Threads REQUIRED)
 
-add_executable(bench bench.cpp)
-target_link_libraries(bench spdlog::spdlog Threads::Threads)
+add_executable(spdlog_bench bench.cpp)
+target_link_libraries(spdlog_bench spdlog::spdlog Threads::Threads)
 
-add_executable(async_bench async_bench.cpp)
-target_link_libraries(async_bench spdlog::spdlog Threads::Threads)
+add_executable(spdlog_async_bench async_bench.cpp)
+target_link_libraries(spdlog_async_bench spdlog::spdlog Threads::Threads)
 
-add_executable(latency latency.cpp)
-target_link_libraries(latency spdlog::spdlog Threads::Threads)
+add_executable(spdlog_latency latency.cpp)
+target_link_libraries(spdlog_latency spdlog::spdlog Threads::Threads)
 
 file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/logs")


### PR DESCRIPTION
https://issues.couchbase.com/browse/MB-30798

Update spdlog to v 1.x. Update to version 1.1 which requires modification of the bench/CMakeLists.txt file so that it does not use the same name as another executable within Couchbase.

https://issues.couchbase.com/browse/MB-30302

KV: Consistent printing of vbucket IDs - vb:123. Update spdlog/details/registry.h to use weak_ptrs instead of shared_ptrs. This allows us to ensure that EP Engine is the only owner of spdlog loggers, which allows us to free their allocated memory when they run out of scope in EP Engine. This requires that the destructor of overridden spdlog loggers unregisters it from the spdlog registry to ensure that the object is always valid.