### PR TITLE
MB-32245: Fix shared_ptr race in spdlog registry

### DIFF
--- a/include/spdlog/details/registry.h
+++ b/include/spdlog/details/registry.h
@@ -85,7 +85,10 @@ public:
         formatter_ = std::move(formatter);
         for (auto &l : loggers_)
         {
-            l.second.lock()->set_formatter(formatter_->clone());
+            auto shared = l.second.lock();
+            if (shared) {
+                shared->set_formatter(formatter_->clone());
+            }
         }
     }
 
@@ -94,7 +97,10 @@ public:
         std::lock_guard<std::mutex> lock(logger_map_mutex_);
         for (auto &l : loggers_)
         {
-            l.second.lock()->set_level(log_level);
+            auto shared = l.second.lock();
+            if (shared) {
+                shared->set_level(log_level);
+            }
         }
         level_ = log_level;
     }
@@ -104,7 +110,10 @@ public:
         std::lock_guard<std::mutex> lock(logger_map_mutex_);
         for (auto &l : loggers_)
         {
-            l.second.lock()->flush_on(log_level);
+            auto shared = l.second.lock();
+            if (shared) {
+                shared->flush_on(log_level);
+            }
         }
         flush_level_ = log_level;
     }
@@ -121,7 +130,10 @@ public:
         std::lock_guard<std::mutex> lock(logger_map_mutex_);
         for (auto &l : loggers_)
         {
-            l.second.lock()->set_error_handler(handler);
+            auto shared = l.second.lock();
+            if (shared) {
+                shared->set_error_handler(handler);
+            }
         }
         err_handler_ = handler;
     }
@@ -131,7 +143,10 @@ public:
         std::lock_guard<std::mutex> lock(logger_map_mutex_);
         for (auto &l : loggers_)
         {
-            fun(l.second.lock());
+            auto shared = l.second.lock();
+            if (shared) {
+                fun(shared);
+            }
         }
     }
 
@@ -140,7 +155,10 @@ public:
         std::lock_guard<std::mutex> lock(logger_map_mutex_);
         for (auto &l : loggers_)
         {
-            l.second.lock()->flush();
+            auto shared = l.second.lock();
+            if (shared) {
+                shared->flush();
+            }
         }
     }
 

--- a/include/spdlog/details/registry.h
+++ b/include/spdlog/details/registry.h
@@ -86,7 +86,8 @@ public:
         for (auto &l : loggers_)
         {
             auto shared = l.second.lock();
-            if (shared) {
+            if (shared)
+            {
                 shared->set_formatter(formatter_->clone());
             }
         }
@@ -98,7 +99,8 @@ public:
         for (auto &l : loggers_)
         {
             auto shared = l.second.lock();
-            if (shared) {
+            if (shared)
+            {
                 shared->set_level(log_level);
             }
         }
@@ -111,7 +113,8 @@ public:
         for (auto &l : loggers_)
         {
             auto shared = l.second.lock();
-            if (shared) {
+            if (shared)
+            {
                 shared->flush_on(log_level);
             }
         }
@@ -131,7 +134,8 @@ public:
         for (auto &l : loggers_)
         {
             auto shared = l.second.lock();
-            if (shared) {
+            if (shared)
+            {
                 shared->set_error_handler(handler);
             }
         }
@@ -144,7 +148,8 @@ public:
         for (auto &l : loggers_)
         {
             auto shared = l.second.lock();
-            if (shared) {
+            if (shared)
+            {
                 fun(shared);
             }
         }
@@ -156,7 +161,8 @@ public:
         for (auto &l : loggers_)
         {
             auto shared = l.second.lock();
-            if (shared) {
+            if (shared)
+            {
                 shared->flush();
             }
         }


### PR DESCRIPTION
In changing the spdlog registry to use weak_ptr's, a race condition
was introduced. A shared_ptr to a BucketLogger may be destructed,
dropping the internal reference count to 0. If any other thread blocks
this thread from unregistering the BucketLogger in the BucketLogger
destructor by acquiring the logger_map_mutex_, then the blocking thread
can access the loggers_ map in an invalid state that can cause a
segmentation fault. This is best described by a diagram found in the
comments on the jira issue.

To fix this, check the validity of the shared_ptr we create when we
call lock() on the stored weak_ptr. If it's not valid, ignore the entry
in the map. The thread currently blocked by the mutex in the drop
function (called by unregisterSpdlogger) will cleanup the map. If we
were to cleanup the map when we find an invalid weak_ptr, we would open
ourselves to another potential issue where we could register another
logger with the same name on a different thread, then unregister it
immediately with the destructing thread (if you ignore that we try to
guarantee unique names). This wouldn't seg fault, but we wouldn't be
able to change the verbosity of the newly created logger.

Change-Id: I54f475901ff26940ecedb1cabc37a29e4347a46c